### PR TITLE
Fixes for Python 3 compatibility and rest framework update

### DIFF
--- a/mapstore2_adapter/api/serializers.py
+++ b/mapstore2_adapter/api/serializers.py
@@ -51,7 +51,7 @@ class JSONArraySerializerField(serializers.Field):
                     "name": _a.name,
                     "type": _a.type,
                     "label": _a.label,
-                    "value": base64.decodestring(_a.value).decode('utf8')
+                    "value": base64.b64decode(_a.value).decode('utf8')
                 })
         else:
             attributes = []

--- a/mapstore2_adapter/api/urls.py
+++ b/mapstore2_adapter/api/urls.py
@@ -15,7 +15,7 @@ from . import views
 
 router = routers.DefaultRouter()
 router.register(r'users', views.UserViewSet)
-router.register(r'resources', views.MapStoreResourceViewSet, base_name="resources")
+router.register(r'resources', views.MapStoreResourceViewSet, basename="resources")
 
 urlpatterns = [
     url(r'^rest/', include(router.urls)),

--- a/mapstore2_adapter/plugins/serializers.py
+++ b/mapstore2_adapter/plugins/serializers.py
@@ -16,16 +16,15 @@ from ..api.models import (MapStoreData,
 
 from rest_framework.exceptions import APIException
 
-try:
-    import json
-except ImportError:
-    from django.utils import simplejson as json
-
+import json
 import base64
 import logging
 import traceback
 from django.http import Http404
-from urlparse import urlparse, parse_qs
+try:
+    from urllib.parse import urlparse, parse_qs
+except ImportError:
+    from urlparse import urlparse, parse_qs
 from geonode.layers.models import Layer
 
 is_analytics_enabled = False
@@ -63,7 +62,7 @@ class GeoNodeSerializer(object):
             attribute.name = _a['name']
             attribute.type = _a['type']
             attribute.label = _a['label']
-            attribute.value = base64.encodestring(_a['value'].encode('utf8'))
+            attribute.value = base64.b64encode(_a['value'].encode('utf8'))
             attribute.save()
             _attributes.append(attribute)
         serializer.validated_data['attributes'] = _attributes


### PR DESCRIPTION
PR to fix map creation in GeoNode as the current version missed a reference to Python 2's urllib. Additionally, the keyword argument `base_name` has been renamed to `basename` in the rest framework.